### PR TITLE
Add notice documenting LGPL modifications to wave_writer files

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,22 @@
+Notice about modifications  
+
+This repository contains code originally written by Shay Green and
+distributed as part of the blip_buf project under the GNU Lesser
+General Public License version 2.1 or later.  
+
+On 25 Nov 2020, Vadim Grigoruk modified the wave_writer example files
+to improve Windows compatibility by adding wide-character file opening
+support for MSVC and MinGW builds.  
+
+These changes introduce a wrapper around file opening that allows
+UTF-8 filenames to be opened using Windows wide-character APIs.  
+
+All modifications remain licensed under the same LGPL license as the
+original code.  
+
+
+
+
 blip_buf $vers: Band-Limited Audio Buffer
 -----------------------------------------
 Blip_buf is a small waveform synthesis library meant for use in classic
@@ -60,3 +79,4 @@ tests/                Unit tests (build with "make test")
 
 -- 
 Shay Green <gblargg@gmail.com>
+

--- a/wave_writer.c
+++ b/wave_writer.c
@@ -20,8 +20,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA */
  * Modified by Vadim Grigoruk, 25 Nov 2020.
  *
  * Changes:
- *  - Updated declarations to match Windows file-opening changes in
- *    wave_writer.c.
+ *  - Added Windows-specific wide-character file opening support for
+ *    MSVC and MinGW builds.
+ *  - Introduced UTF-8 to wide-character conversion helper for filenames.
+ *  - Added ww_fopen() wrapper using _wfopen() on Windows.
+ *  - Replaced direct fopen() usage with ww_fopen().
  *
  * Original code by Shay Green.
  *

--- a/wave_writer.c
+++ b/wave_writer.c
@@ -16,6 +16,19 @@ details. You should have received a copy of the GNU Lesser General Public
 License along with this module; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA */
 
+/*
+ * Modified by Vadim Grigoruk, 25 Nov 2020.
+ *
+ * Changes:
+ *  - Updated declarations to match Windows file-opening changes in
+ *    wave_writer.c.
+ *
+ * Original code by Shay Green.
+ *
+ * This file remains licensed under the GNU Lesser General Public
+ * License, version 2.1 or later. See the project LICENSE file.
+ */
+
 enum { sample_size = 2 };
 
 static FILE* file;

--- a/wave_writer.h
+++ b/wave_writer.h
@@ -1,3 +1,17 @@
+/*
+ * Modified by Vadim Grigoruk, 25 Nov 2020.
+ *
+ * Changes:
+ *  - Updated declarations to match Windows file-opening changes in
+ *    wave_writer.c.
+ *
+ * Original code by Shay Green.
+ *
+ * This file remains licensed under the GNU Lesser General Public
+ * License, version 2.1 or later. See the project LICENSE file.
+ */
+
+
 /* Simple wave sound file writer for use in demo programs. */
 
 #ifndef WAVE_WRITER_H


### PR DESCRIPTION
This PR adds a notice documenting previously made modifications to the wave_writer files.  

The affected code originates from blip_buf by Shay Green, which is licensed under the GNU Lesser General Public License v2.1 or later. A notice has been added to clarify the origin of the code and describe later modifications made in this repository.  

Specifically, on 25 Nov 2020, Vadim Grigoruk modified the wave_writer files to improve Windows compatibility by adding wide-character file opening support for MSVC and MinGW builds. The change introduces a wrapper around file opening that allows UTF-8 filenames to be opened through Windows wide-character APIs.  